### PR TITLE
disable external gpu

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -625,6 +625,8 @@
 			</dict>
 			<key>PciRoot(0x0)/Pci(0x2,0x0)</key>
 			<dict>
+			<key>disable-external-gpu</key>
+			<data>AQAAAA==</data>
 			<key>AAPL,ig-platform-id</key>
 			<data>AACbPg==</data>
 			<key>AAPL,slot-name</key>


### PR DESCRIPTION
we'd better to disable mx250 to make suspend & resume works.

Signed-off-by: schspa <schspa@gmail.com>