### PR TITLE
Update config_ps2.plist

### DIFF
--- a/OC/config_ps2.plist
+++ b/OC/config_ps2.plist
@@ -1254,13 +1254,13 @@
 				<key>SystemAudioVolume</key>
 				<data>Rg==</data>
 				<key>boot-args</key>
-				<string>keepsyms=1 debug=0x100</string>
+				<string>keepsyms=1 debug=0x100 alcid=11 -wegnoegpu</string>
 				<key>run-efi-updater</key>
 				<string>No</string>
 				<key>csr-active-config</key>
 				<data>5wMAAA==</data>
 				<key>prev-lang:kbd</key>
-				<data>cnUtUlU6MjUy</data>
+				<string>en-US:0</string>
 			</dict>
 		</dict>
 		<key>Delete</key>


### PR DESCRIPTION
- Recognise audio card properly and HDMI/DP audio outputs
- Make the recovery work in English instead of Russian