### PR TITLE
fix PlayChime setup.

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -1541,7 +1541,7 @@
 			<key>MinimumVolume</key>
 			<integer>20</integer>
 			<key>PlayChime</key>
-			<false/>
+			<string>Disabled</string>
 			<key>SetupDelay</key>
 			<integer>0</integer>
 			<key>VolumeAmplifier</key>


### PR DESCRIPTION
PlayChime was changed to string after OC v0.6.4.

Signed-off-by: schspa <schspa@gmail.com>