### PR TITLE
Fix syntax error in config.plist

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -1415,7 +1415,7 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
-				<false/><>
+				<false/>
 				<key>Flavour</key>
 				<string>Auto</string>
 				<key>Name</key>


### PR DESCRIPTION
I noticed this while trying to enable verbose booting, there was a `<>` present that shouldn't be there so I removed it. Everything should work as normal now.